### PR TITLE
Make the WFError enum public so it's available to clients

### DIFF
--- a/Sources/WriteFreely/WFError.swift
+++ b/Sources/WriteFreely/WFError.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum WFError: Int, Error {
+public enum WFError: Int, Error {
     case badRequest = 400
     case unauthorized = 401
     case forbidden = 403


### PR DESCRIPTION
Closes #15.

This is a patch change to fix a bug that prevents consumers of the package from accessing the WFError type.