### PR TITLE
Adds a simple memberwise-ish initializer for stored token/username

### DIFF
--- a/Sources/WriteFreely/WFUser.swift
+++ b/Sources/WriteFreely/WFUser.swift
@@ -23,6 +23,19 @@ extension WFUser: Decodable {
         case createdDate = "created"
     }
 
+    /// Creates a minimum `WFUser` object from a stored token.
+    ///
+    /// Use this when the client has already logged in a user and only needs to reconstruct the type from saved properties.
+    ///
+    /// - Parameter token: The user's access token
+    /// - Parameter username: The user's username (optional)
+    public init(token: String, username: String?) {
+        self.token = token
+        if let username = username {
+            self.username = username
+        }
+    }
+
     /// Creates a `WFUser` object from the server response.
     ///
     ///  Primarily used by the `WFClient` to create a `WFUser` object from the JSON returned by the server.

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -2,5 +2,6 @@
 
   - [WFClient](/WFClient)
   - [WFCollection](/WFCollection)
+  - [WFError](/WFError)
   - [WFPost](/WFPost)
   - [WFUser](/WFUser)

--- a/docs/WFError.md
+++ b/docs/WFError.md
@@ -1,0 +1,77 @@
+# WFError
+
+``` swift
+public enum WFError
+```
+
+## Inheritance
+
+`Error`, `Int`
+
+## Enumeration Cases
+
+### `badRequest`
+
+``` swift
+case badRequest
+```
+
+### `unauthorized`
+
+``` swift
+case unauthorized
+```
+
+### `forbidden`
+
+``` swift
+case forbidden
+```
+
+### `notFound`
+
+``` swift
+case notFound
+```
+
+### `methodNotAllowed`
+
+``` swift
+case methodNotAllowed
+```
+
+### `gone`
+
+``` swift
+case gone
+```
+
+### `preconditionFailed`
+
+``` swift
+case preconditionFailed
+```
+
+### `tooManyRequests`
+
+``` swift
+case tooManyRequests
+```
+
+### `internalServerError`
+
+``` swift
+case internalServerError
+```
+
+### `badGateway`
+
+``` swift
+case badGateway
+```
+
+### `serviceUnavailable`
+
+``` swift
+case serviceUnavailable
+```

--- a/docs/WFUser.md
+++ b/docs/WFUser.md
@@ -10,6 +10,21 @@ public struct WFUser
 
 ## Initializers
 
+### `init(token:username:)`
+
+Creates a minimum `WFUser` object from a stored token.
+
+``` swift
+public init(token: String, username: String?)
+```
+
+Use this when the client has already logged in a user and only needs to reconstruct the type from saved properties.
+
+#### Parameters
+
+  - token: - token: The user's access token
+  - username: - username: The user's username (optional)
+
 ### `init(from:)`
 
 Creates a `WFUser` object from the server response.

--- a/docs/_Footer.md
+++ b/docs/_Footer.md
@@ -1,1 +1,1 @@
-Generated at 2020-08-17T10:42:50-0400 using [swift-doc](https://github.com/SwiftDocOrg/swift-doc) 1.0.0-beta.3.
+Generated at 2020-08-31T10:27:33-0400 using [swift-doc](https://github.com/SwiftDocOrg/swift-doc) 1.0.0-beta.3.

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -3,6 +3,7 @@
 
   - [WFClient](/WFClient)
   - [WFCollection](/WFCollection)
+  - [WFError](/WFError)
   - [WFPost](/WFPost)
   - [WFUser](/WFUser)
 


### PR DESCRIPTION
Closes #18.

This PR adds a minimal initializer for the WFUser type such that it can be reconstructed from saved properties because it turns out, if you provide a custom initializer to a Swift struct, you no longer get the memberwise initializer that's automatically synthesized by the compiler.

¯\\_(ツ)\_/¯