### PR TITLE
Don't return early if we get a 404 on login attempt

### DIFF
--- a/Sources/WriteFreely/WFClient.swift
+++ b/Sources/WriteFreely/WFClient.swift
@@ -924,7 +924,11 @@ public class WFClient {
                     }
                 } else {
                     // We didn't get a 200 OK, so return a WFError
-                    guard let error = self.translateWFError(fromServerResponse: data) else { return }
+                    guard let error = self.translateWFError(fromServerResponse: data) else {
+                        // We couldn't generate a WFError from the server response data, so return an unknown error.
+                        completion(.failure(WFError.unknownError))
+                        return
+                    }
                     completion(.failure(error))
                 }
             }
@@ -1088,7 +1092,8 @@ private extension WFClient {
             print("⛔️ \(error.message)")
             return WFError(rawValue: error.code)
         } catch {
-            return nil
+            print("⛔️ An unknown error occurred.")
+            return WFError.unknownError
         }
     }
 }

--- a/Sources/WriteFreely/WFError.swift
+++ b/Sources/WriteFreely/WFError.swift
@@ -12,6 +12,7 @@ public enum WFError: Int, Error {
     case internalServerError = 500
     case badGateway = 502
     case serviceUnavailable = 503
+    case unknownError = -1
 }
 
 struct ErrorMessage: Codable {


### PR DESCRIPTION
Closes #21.

This PR adds an `.unknownError` case to the WFError type and makes sure we return it if the error can't be generated from the server response (i.e., when trying to log in to a server that doesn't host a WriteFreely instance).