### PR TITLE
Extend move api to drafts

### DIFF
--- a/Sources/WriteFreely/WFClient.swift
+++ b/Sources/WriteFreely/WFClient.swift
@@ -327,7 +327,7 @@ public class WFClient {
     /// - Parameters:
     ///   - token: The access token for the user moving the post to a collection.
     ///   - postId: The ID of the post to add to the collection.
-    ///   - modifyToken: The post's modify token; required if the post doesn't belong to the requesting user.
+    ///   - modifyToken: The post's modify token; required if the post doesn't belong to the requesting user. If `collectionAlias` is `nil`, do not include a `modifyToken`.
     ///   - collectionAlias: The alias of the collection to which the post should be added; if `nil`, this removes the post from any collection.
     ///   - completion: A handler for the returned `Bool` on success, or `Error` on failure.
     public func movePost(
@@ -339,6 +339,8 @@ public class WFClient {
     ) {
         if token == nil && user == nil { return }
         guard let tokenToVerify = token ?? user?.token else { return }
+
+        if collectionAlias == nil && modifyToken != nil { completion(.failure(WFError.badRequest)) }
 
         var urlString = ""
         if let collectionAlias = collectionAlias {
@@ -355,7 +357,7 @@ public class WFClient {
 
         var bodyObject: [Any]
         if let modifyToken = modifyToken {
-            bodyObject = collectionAlias == nil ? [ postId ] : [ [ "id": postId, "token": modifyToken ] ]
+            bodyObject = [ [ "id": postId, "token": modifyToken ] ]
         } else {
             bodyObject = collectionAlias == nil ? [ postId ] : [ [ "id": postId ] ]
         }

--- a/Sources/WriteFreely/WFClient.swift
+++ b/Sources/WriteFreely/WFClient.swift
@@ -328,19 +328,25 @@ public class WFClient {
     ///   - token: The access token for the user moving the post to a collection.
     ///   - postId: The ID of the post to add to the collection.
     ///   - modifyToken: The post's modify token; required if the post doesn't belong to the requesting user.
-    ///   - collectionAlias: The alias of the collection to which the post should be added.
+    ///   - collectionAlias: The alias of the collection to which the post should be added; if `nil`, this removes the post from any collection.
     ///   - completion: A handler for the returned `Bool` on success, or `Error` on failure.
     public func movePost(
         token: String? = nil,
         postId: String,
         with modifyToken: String? = nil,
-        to collectionAlias: String,
+        to collectionAlias: String?,
         completion: @escaping (Result<Bool, Error>) -> Void
     ) {
         if token == nil && user == nil { return }
         guard let tokenToVerify = token ?? user?.token else { return }
 
-        guard let url = URL(string: "collections/\(collectionAlias)/collect", relativeTo: requestURL) else { return }
+        var urlString = ""
+        if let collectionAlias = collectionAlias {
+            urlString = "collections/\(collectionAlias)/collect"
+        } else {
+            urlString = "posts/disperse"
+        }
+        guard let url = URL(string: urlString, relativeTo: requestURL) else { return }
         var request = URLRequest(url: url)
 
         request.httpMethod = "POST"

--- a/Sources/WriteFreely/WFClient.swift
+++ b/Sources/WriteFreely/WFClient.swift
@@ -353,20 +353,11 @@ public class WFClient {
         request.addValue("application/json; charset=utf-8", forHTTPHeaderField: "Content-Type")
         request.addValue(tokenToVerify, forHTTPHeaderField: "Authorization")
 
-        var bodyObject: [[String: Any]]
+        var bodyObject: [Any]
         if let modifyToken = modifyToken {
-            bodyObject = [
-                [
-                    "id": postId,
-                    "token": modifyToken
-                ]
-            ]
+            bodyObject = collectionAlias == nil ? [ postId ] : [ [ "id": postId, "token": modifyToken ] ]
         } else {
-            bodyObject = [
-                [
-                    "id": postId
-                ]
-            ]
+            bodyObject = collectionAlias == nil ? [ postId ] : [ [ "id": postId ] ]
         }
 
         do {


### PR DESCRIPTION
Closes #23.

This PR extends the `movePost()` API to move posts between collections, and also out of _any_ collection.