### PR TITLE
Fix build errors and add back testing files

### DIFF
--- a/Sources/WriteFreely/WFClient+Templates.swift
+++ b/Sources/WriteFreely/WFClient+Templates.swift
@@ -17,7 +17,7 @@ extension WFClient {
                 return
             }
 
-            guard let response = response as? HTTPURLResponse, response.statusCode == 200 else {
+            guard let unwrappedResponse = response as? HTTPURLResponse, unwrappedResponse.statusCode == 200 else {
                 if let response = response as? HTTPURLResponse {
                     completion(.failure(WFError(rawValue: response.statusCode) ?? .invalidResponse))
                 } else {
@@ -57,7 +57,7 @@ extension WFClient {
                 return
             }
 
-            guard let response = response as? HTTPURLResponse, response.statusCode == statusCode else {
+            guard let unwrappedResponse = response as? HTTPURLResponse, unwrappedResponse.statusCode == statusCode else {
                 if let response = response as? HTTPURLResponse {
                     completion(.failure(WFError(rawValue: response.statusCode) ?? .invalidResponse))
                 } else {
@@ -92,7 +92,7 @@ extension WFClient {
                 return
             }
 
-            guard let response = response as? HTTPURLResponse, response.statusCode == 204 else {
+            guard let unwrappedResponse = response as? HTTPURLResponse, unwrappedResponse.statusCode == 204 else {
                 if let response = response as? HTTPURLResponse {
                     completion(.failure(WFError(rawValue: response.statusCode) ?? .invalidResponse))
                 } else {

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,0 +1,7 @@
+import XCTest
+
+import WriteFreelyTests
+
+var tests = [XCTestCaseEntry]()
+tests += WriteFreelyTests.allTests()
+XCTMain(tests)

--- a/Tests/WriteFreelyTests/WriteFreelyTests.swift
+++ b/Tests/WriteFreelyTests/WriteFreelyTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+@testable import WriteFreely
+
+final class WriteFreelyTests: XCTestCase {
+    func testExample() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct
+        // results.
+        XCTAssertEqual(true, !false)
+    }
+
+    static var allTests = [
+        ("testExample", testExample),
+    ]
+}

--- a/Tests/WriteFreelyTests/XCTestManifests.swift
+++ b/Tests/WriteFreelyTests/XCTestManifests.swift
@@ -1,0 +1,9 @@
+import XCTest
+
+#if !canImport(ObjectiveC)
+public func allTests() -> [XCTestCaseEntry] {
+    return [
+        testCase(WriteFreelyTests.allTests),
+    ]
+}
+#endif


### PR DESCRIPTION
Closes #5.

Currently the package is reported as failing to build on the [Swift Package Index](https://swiftpackageindex.com/writefreely/writefreely-swift/builds) for v0.3.1 — this should be fixed by:

1. Using a more backwards-compatible unwrapping of the response in the request templates; and
2. Adding back the boilerplate files for package tests (without actually adding any tests yet).

This now lets the following commands run successfully:

```zsh
% swift build -v
% swift test -v
```

I also [added a GitHub Action](https://github.com/writefreely/writefreely-swift/commit/7fd1c6aaf14a81779e6e2d60f3a87f70e5f48bd4) to build and test new PRs and pushes to `main`.