### PR TITLE
Extend date decoding strategy for possible fractional seconds

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,8 +6,8 @@ import PackageDescription
 let package = Package(
     name: "WriteFreely",
     platforms: [
-        .macOS(.v10_12),
-        .iOS(.v10)
+        .macOS(.v10_13),
+        .iOS(.v11)
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.

--- a/Sources/WriteFreely/Extensions/JSONDecoder+Extension.swift
+++ b/Sources/WriteFreely/Extensions/JSONDecoder+Extension.swift
@@ -6,13 +6,19 @@ extension JSONDecoder.DateDecodingStrategy {
 
     /// The strategy that formats dates according to the ISO 8601 standard.
     /// - Note: This includes the fractional seconds, unlike the standard `.iso8601`, which fails to decode those.
-    static var iso8601WithFractionalSeconds: JSONDecoder.DateDecodingStrategy {
+    static var iso8601WithPossibleFractionalSeconds: JSONDecoder.DateDecodingStrategy {
         JSONDecoder.DateDecodingStrategy.custom { (decoder) in
             let singleValue = try decoder.singleValueContainer()
             let dateString  = try singleValue.decode(String.self)
 
             let formatter = ISO8601DateFormatter()
-            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+            /// Use the `.withFractionalSeconds` option only if we have fractional seconds in the date string.
+            if dateString.contains(".") {
+                formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            } else {
+                formatter.formatOptions = [.withInternetDateTime]
+            }
 
             guard let date = formatter.date(from: dateString) else {
                 throw DecodingError.dataCorruptedError(

--- a/Sources/WriteFreely/Extensions/JSONDecoder+Extension.swift
+++ b/Sources/WriteFreely/Extensions/JSONDecoder+Extension.swift
@@ -1,0 +1,27 @@
+// Credit: https://github.com/vapor/vapor/issues/2481#issuecomment-702013846
+
+import Foundation
+
+extension JSONDecoder.DateDecodingStrategy {
+
+    /// The strategy that formats dates according to the ISO 8601 standard.
+    /// - Note: This includes the fractional seconds, unlike the standard `.iso8601`, which fails to decode those.
+    static var iso8601WithFractionalSeconds: JSONDecoder.DateDecodingStrategy {
+        JSONDecoder.DateDecodingStrategy.custom { (decoder) in
+            let singleValue = try decoder.singleValueContainer()
+            let dateString  = try singleValue.decode(String.self)
+
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+            guard let date = formatter.date(from: dateString) else {
+                throw DecodingError.dataCorruptedError(
+                    in: singleValue,
+                    debugDescription: "Failed to decode string to ISO 8601 date."
+                )
+            }
+            return date
+        }
+    }
+
+}

--- a/Sources/WriteFreely/WFClient.swift
+++ b/Sources/WriteFreely/WFClient.swift
@@ -31,7 +31,7 @@ public class WFClient {
     ///   - session: The URL session to use for connections; defaults to `URLSession.shared`.
     public init(for instanceURL: URL, with session: URLSessionProtocol = URLSession.shared) {
         decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601WithFractionalSeconds
+        decoder.dateDecodingStrategy = .iso8601WithPossibleFractionalSeconds
 
         self.session = session
 

--- a/Sources/WriteFreely/WFClient.swift
+++ b/Sources/WriteFreely/WFClient.swift
@@ -31,7 +31,7 @@ public class WFClient {
     ///   - session: The URL session to use for connections; defaults to `URLSession.shared`.
     public init(for instanceURL: URL, with session: URLSessionProtocol = URLSession.shared) {
         decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
+        decoder.dateDecodingStrategy = .iso8601WithFractionalSeconds
 
         self.session = session
 


### PR DESCRIPTION
This PR closes #34 by checking if there's a fractional second value in the returned date string, and setting `.withFractionalSeconds` in the formatter if relevant in the custom date decoding strategy.

We naïvely check for a fractional second value simply by verifying if the `"."` character exists in the date string.